### PR TITLE
Move php-http/guzzle7-adapter to require section

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,12 +17,12 @@
         "illuminate/routing": "~5.8.0|^6.0|^7.0|^8.0|^9.0",
         "cloudconvert/cloudconvert-php": "^3.1.0",
         "symfony/psr-http-message-bridge": "^1.2|^2.0",
-        "nyholm/psr7": "^1.2"
+        "nyholm/psr7": "^1.2",
+        "php-http/guzzle7-adapter": "^1.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^7.0|^8.0|^9.5.10",
-        "orchestra/testbench": "~3.8.0|^4.0|^5.0|^6.0|^7.0",
-        "php-http/guzzle7-adapter": "^1.0"
+        "orchestra/testbench": "~3.8.0|^4.0|^5.0|^6.0|^7.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
This PR. fixes the following error when installing the package:
```shell
  Problem 1
    - cloudconvert/cloudconvert-php[3.1.0, ..., 3.3.0] require php-http/client-implementation ^1.0 || ^2.0 -> could not be found in any version, but the following packages provide it:
      - symfony/http-client Provides powerful methods to fetch HTTP resources synchronously or asynchronously
      - php-http/guzzle6-adapter Guzzle 6 HTTP Adapter
      - symfony/symfony The Symfony PHP framework
      - php-http/curl-client PSR-18 and HTTPlug Async client with cURL
      - php-http/guzzle7-adapter Guzzle 7 HTTP Adapter
      - kriswallsmith/buzz Lightweight HTTP client
      - php-http/mock-client Mock HTTP client
      - php-http/socket-client Socket client for PHP-HTTP
      - php-http/guzzle5-adapter Guzzle 5 HTTP Adapter
      - voku/httpful A Readable, Chainable, REST friendly, PHP HTTP Client
      - jorge-matricali/http-client A wrapper of libcurl that implements PSR-7 HTTP message interface.
      - juststeveking/http-slim A slim psr compliant http client to provide better interoperability.
      - php-http/react-adapter React HTTP Adapter
      - php-http/buzz-adapter Buzz HTTP Adapter
      - code-tool/curl-client cURL client
      - code-tool/socket-client Socket client for PHP-HTTP
      - php-http/cakephp-adapter Cake adapter for PHP-HTTP
      - windwalker/http Windwalker Http package
      - windwalker/framework The next generation PHP framework.
      - swisnl/php-http-fixture-client Fixture client for PHP-HTTP
      ... and 36 more.
      Consider requiring one of these to satisfy the php-http/client-implementation requirement.
    - Root composer.json requires cloudconvert/cloudconvert-php ^3.1.0 -> satisfiable by cloudconvert/cloudconvert-php[3.1.0, ..., 3.3.0].
```
fixes 